### PR TITLE
fix: st-stats as polymer element

### DIFF
--- a/graphics/elements/st-stats/st-stats.js
+++ b/graphics/elements/st-stats/st-stats.js
@@ -2,14 +2,23 @@
 (function () {
 	'use strict';
 
-	nodecg.listenFor('showStats', function () {
-		document.getElementById("st-stats").innerHTML = "SHOWED";
-		document.getElementById("st-stats").style.display = "block";
-	});
+	Polymer({
+		is: 'st-stats',
 
-	nodecg.listenFor('hideStats', function () {
-		document.getElementById("st-stats").innerHTML = "HIDDED";
-		document.getElementById("st-stats").style.display = "none";
-	});
+		properties: {},
 
+		ready() {
+			const self = this;
+
+			nodecg.listenFor('showStats', function() {
+				document.getElementById('st-stats').style.display = 'block';
+				self.$.data_container.innerHTML = 'SHOWED';
+			});
+
+			nodecg.listenFor('hideStats', function() {
+				document.getElementById('st-stats').style.display = 'none';
+				self.$.data_container.innerHTML = 'HIDDEN';
+			});
+		}
+	})
 })();


### PR DESCRIPTION
When you use `template`, you also want to create a Polymer element.
If you do not create a Polymer element with the same name as your dom-module (`st-stats`), Polymer does not know how to handle the contents of `template`.

I  believe that's a requirement in Polymer 1, which is what your project is using.